### PR TITLE
deal with svgs protected by cors

### DIFF
--- a/src/scripts/create-card.js
+++ b/src/scripts/create-card.js
@@ -91,20 +91,34 @@ export function createCards(svgInfo, cont) {
     createElement('div', 'gob__attrcont', gobblerCardFooter, hasAttr(el))
 
     // create download buttons
-    const dOpti = createElement('button', 'gob__btn')
-    dOpti.classList.add('gob__btn--download')
-    dOpti.addEventListener('click', () => {
-      toggleSuccess(dOpti, 'gob__btn--success--download')
-      download.createOptiDownload(el)
-    })
-    gobblerCardBtns.appendChild(dOpti)
+    if (el.svgString.length > 0) {
+      const dOpti = createElement('button', 'gob__btn')
+      dOpti.classList.add('gob__btn--download')
+      dOpti.addEventListener('click', () => {
+        toggleSuccess(dOpti, 'gob__btn--success--download')
+        download.createOptiDownload(el)
+      })
+      gobblerCardBtns.appendChild(dOpti)
+    } else {
+      // unfortunately, this opens it instead of downloading because of same-origin policies
+      // https://developer.mozilla.org/en-US/docs/Web/HTML/Element/a
+      const dOpti = createElement('a', 'gob__btn')
+      dOpti.classList.add('gob__btn--download')
+      dOpti.setAttribute("download", "gobble-unoptimized.svg");  // does not have an effect
+      dOpti.setAttribute("target", "_blank");
+      dOpti.setAttribute("href", el.url);
+      gobblerCardBtns.appendChild(dOpti)
+    }
 
-    const cOpti = createElement('button', 'gob__btn')
-    cOpti.classList.add('gob__btn--copy')
-    cOpti.addEventListener('click', () => {
-      toggleSuccess(cOpti, 'gob__btn--success--copy')
-      download.copyOptiClipboard(el)
-    })
-    gobblerCardBtns.appendChild(cOpti)
+    if (el.svgString.length > 0) {
+      console.log('svgstring: ', el.svgString);
+      const cOpti = createElement('button', 'gob__btn')
+      cOpti.classList.add('gob__btn--copy')
+      cOpti.addEventListener('click', () => {
+        toggleSuccess(cOpti, 'gob__btn--success--copy')
+        download.copyOptiClipboard(el)
+      })
+      gobblerCardBtns.appendChild(cOpti)
+    }
   })
 }

--- a/src/scripts/organize-svgs.js
+++ b/src/scripts/organize-svgs.js
@@ -13,23 +13,21 @@ class SVG {
     let parser = new DOMParser()
 
     if (this.url) {
-      return fetch(this.url)
-        .then(response => {
-          return response.text()
-        })
-        .then(response => {
-          const xml = parser.parseFromString(response, 'image/svg+xml')
-            .children[0]
-          const string = serializer.serializeToString(xml)
-          this.svgString = string
-          this.svgXml = xml
-        })
+      let response = await fetch(this.url, { mode: 'no-cors'});
+
+      if (response.type === 'opaque') {
+        this.svgString = '';
+        this.svgXml = this.ele;
+        return;
+      }
+      
+      const xml = parser.parseFromString(response.text(), 'image/svg+xml').children[0]
+      const string = serializer.serializeToString(xml)
+      this.svgString = string
+      this.svgXml = xml
     } else {
-      return new Promise((resolve, reject) => {
-        this.svgString = this.ele.eleString
-        this.svgXml = this.ele
-        resolve()
-      })
+      this.svgString = this.ele.eleString;
+      this.svgXml = this.ele;
     }
   }
 


### PR DESCRIPTION
A good example of where gobbler was failing: [segment](https://segment.com/).

There should probably be a warning (like the sprite and symbol ones).

I could not find a way to force the download: with this PR, they just open in a new window.  I'm not sure that it will be possible, so maybe rename the button?