### PR TITLE
Fix "TypeError: Cannot read property tagName of null" for childless SVGs

### DIFF
--- a/src/scripts/find-svgs.js
+++ b/src/scripts/find-svgs.js
@@ -2,10 +2,10 @@ class ManageSVGs {
   filterSVGs(el) {
     if (el.tagName === 'svg') {
       const firstChild = el.firstElementChild
-      if (firstChild.tagName === 'symbol') {
+      if (firstChild && firstChild.tagName === 'symbol') {
         el.type = 'symbol'
         el.spriteId = el.getAttribute('id')
-      } else if (firstChild.tagName === 'use') {
+      } else if (firstChild && firstChild.tagName === 'use') {
         el.type = 'sprite'
         el.spriteId = firstChild.getAttributeNS(
           'http://www.w3.org/1999/xlink',


### PR DESCRIPTION
Currently, the extension fails if there are any SVG elements loaded that don't have any child elements, since this is checked unsafely in `filterSVGs`. The exact error thrown in the UI is:
```
😢 There's an error: "TypeError: Cannot read property 'tagName' of null"
```

While it may be better to exclude these elements altogether, checking the existence of the SVG's `firstChild` at least allows all other SVGs to be processed correctly (and in theory an SVG without children could still have elements or CSS attached).

We specifically ran into this as a common case in SVGs created by Google Data Studio, as an empty SVG is often created when there isn't available data for a chart (or as a placeholder in other cases).

(Future fixes should probably make it easier to find the elements causing errors, since it's quite a pain currently as referenced in Issue #26 )