### PR TITLE
SVGs can now be exported as PNG and JPG

### DIFF
--- a/src/scripts/create-card.js
+++ b/src/scripts/create-card.js
@@ -107,6 +107,24 @@ export function createCards(svgInfo, cont) {
         download.copyOptiClipboard(el)
       })
       gobblerCardBtns.appendChild(cOpti)
+
+      // PNG options
+      const pOpti = createElement('button', 'gob__btn')
+      pOpti.classList.add('gob__btn--pngdownload')
+      pOpti.addEventListener('click', () => {
+        toggleSuccess(pOpti, 'gob__btn--success--pngdownload')
+        download.createOptimizedExportedDownload(el, 'png')
+      })
+      gobblerCardBtns.appendChild(pOpti)
+
+      // JPG options
+      const jOpti = createElement('button', 'gob__btn')
+      jOpti.classList.add('gob__btn--jpgdownload')
+      jOpti.addEventListener('click', () => {
+        toggleSuccess(jOpti, 'gob__btn--success--jpgdownload')
+        download.createOptimizedExportedDownload(el, 'jpg')
+      })
+      gobblerCardBtns.appendChild(jOpti)
     } else {
       // adds alert to card
       const newTag = createElement('div', 'gob__tag--cors')

--- a/src/scripts/download-svgs.js
+++ b/src/scripts/download-svgs.js
@@ -135,6 +135,29 @@ class ButtonHandler {
     })
   }
 
+  createOptimizedExportedDownload(i, fileExt) {
+    const filename = fileName()
+    svgo.optimize(i.svgString).then(function(result) {
+      const canvas = document.createElement('canvas')
+      canvas.width = i.svgXml.width.baseVal.value
+      canvas.height = i.svgXml.height.baseVal.value
+      canvas.style.width = i.svgXml.width.baseVal.value
+      canvas.style.height = i.svgXml.height.baseVal.value
+      const ctx = canvas.getContext('2d')
+      const img = document.createElement('img')
+      img.setAttribute(
+        'src',
+        'data:image/svg+xml;base64,' +
+          btoa(unescape(encodeURIComponent(result.data)))
+      )
+      img.onload = function() {
+        ctx.drawImage(img, 0, 0)
+        let imgURI = canvas.toDataURL('image/' + fileExt, 1)
+        FileSaver.saveAs(imgURI, `${filename}.${fileExt}`)
+      }
+    })
+  }
+
   createRegDownload(i) {
     let blob = new Blob([i.svgString], { type: 'text/xml' })
     FileSaver.saveAs(blob, `${filename}.svg`)

--- a/src/styles/index.scss
+++ b/src/styles/index.scss
@@ -206,7 +206,7 @@ html {
       margin: 0 16px;
       line-height: 1.4;
       padding: 12px 0 16px;
-      min-height: 40px;
+      min-height: 90px;
       border-top: 1px solid $gray2;
       position: relative;
       overflow: hidden;
@@ -323,6 +323,14 @@ html {
       content: 'Download';
     }
 
+    &--pngdownload::before {
+      content: 'Export PNG';
+    }
+
+    &--jpgdownload::before {
+      content: 'Export JPG';
+    }
+
     &--copy::before {
       content: 'Copy';
     }
@@ -341,6 +349,16 @@ html {
 
       &--download::before {
         content: 'Gobble';
+        transition: all 0.2s ease-in-out;
+      }
+
+      &--pngdownload::before {
+        content: 'Exported';
+        transition: all 0.2s ease-in-out;
+      }
+
+      &--jpgdownload::before {
+        content: 'Exported';
         transition: all 0.2s ease-in-out;
       }
 


### PR DESCRIPTION
Implements #11 
@rossmoody, Ideally I would like to see a flyout button portion on the 'Download' button but my scss isn't up to par with that.

Let me know what you think about this. Dimensions are taken from the svg width and height (as shown in DOM):
<img width="546" alt="Screen Shot 2020-01-11 at 9 52 36 PM" src="https://user-images.githubusercontent.com/25326067/72213448-f9f06a00-34bc-11ea-8763-ba1665739a3a.png">

