### PR TITLE
Fix incorrect viewBox width/height parameter order

### DIFF
--- a/src/scripts/classify-svg.js
+++ b/src/scripts/classify-svg.js
@@ -114,7 +114,7 @@ const classify = {
 
     if (ele.nodeName === 'svg') {
       if (!ele.hasAttribute('viewBox')) {
-        ele.setAttribute('viewBox', `0 0 ${this.height} ${this.width}`)
+        ele.setAttribute('viewBox', `0 0 ${this.width} ${this.height}`)
       }
 
       ele.removeAttribute('height')


### PR DESCRIPTION
According to the [SVG spec](https://www.w3.org/TR/SVG2/coords.html#ViewBoxAttribute), the viewBox attribute parameters should be `min-x min-y width height`—whereas `width` and `height` are swapped in the current version, leading to badly sized previews when SVGs match this block.