### PR TITLE
Fix failure to gobble on pages with childless SVGs

### DIFF
--- a/src/scripts/classify-svg.js
+++ b/src/scripts/classify-svg.js
@@ -4,8 +4,8 @@ const classify = {
       const firstChild = this.origEle.firstElementChild
 
       if (
-        (firstChild && firstChild.tagName === 'symbol') ||
-        firstChild.tagName === 'defs'
+        firstChild &&
+        (firstChild.tagName === 'symbol' || firstChild.tagName === 'defs')
       ) {
         this.type = 'symbol'
       } else if (firstChild && firstChild.tagName === 'use') {


### PR DESCRIPTION
On pages with SVGs that contain placeholders (sometimes those that are being dynamically created, or are used for control of other elements), v2.5 currently fails to gather SVGs due to a script error:
`Cannot read property 'tagName' of null`

This turned out to be a simple misgrouping of operators, which is corrected in this commit.