### PR TITLE
cover descendants and PARENT in the DOM tree

### DIFF
--- a/src/process/SVG.ts
+++ b/src/process/SVG.ts
@@ -188,7 +188,8 @@ export default class SVG {
       'image/svg+xml',
     )
 
-    if (documentElement.querySelector('parsererror')) {
+    if (documentElement.querySelector('parsererror')
+       || documentElement.tagName.toLowerCase() === 'parsererror') {
       this.type === 'invalid'
     } else {
       this.element = documentElement


### PR DESCRIPTION
Sometimes `documentElement` will be `<parsererror .../>` so checking descendants with `querySelector` won't work.