### PR TITLE
fix: fix prefix_id not working properly

### DIFF
--- a/src/providers/details/reducer.ts
+++ b/src/providers/details/reducer.ts
@@ -275,6 +275,13 @@ export const detailsReducer = (state: DetailsState, action: DetailsAction): Deta
     case 'update-name': {
       return {
         ...state,
+        export: {
+          ...state.export,
+          svgoConfig: {
+            ...state.export.svgoConfig,
+            path: action.payload,
+          },
+        },
         name: action.payload,
       }
     }
@@ -305,6 +312,13 @@ export const detailsReducer = (state: DetailsState, action: DetailsAction): Deta
         ...state,
         collectionId: action.payload.collectionId,
         currentString: action.payload.svg.svg,
+        export: {
+          ...state.export,
+          svgoConfig: {
+            ...state.export.svgoConfig,
+            path: action.payload.svg.name,
+          },
+        },
         id: action.payload.svg.id,
         name: action.payload.svg.name,
         originalName: action.payload.svg.name,


### PR DESCRIPTION
When I check the Prefix IDs option, the prefix IDs are not updated correctly.

### Actual behavior:

```
id="xxx"  -> id="svg_gobbler_xxx"
```

### Expected behavior

```
id="xxx"  -> id="${svg_name}_xxx"
```
The prefix ID must be the same as the svg name.

### Reason
The cause of the bug is that the `export.svgoConfig.path` in the `state` has not been updated

###

This plugin is fantastic, thanks for your work！
